### PR TITLE
feat!: compose ToolDef on primitives ToolSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ BREAKING:
 
 ADDED:
 - `Deref<Target = ToolSchema>` for `ToolDef`.
+- `ToolSchema` is re-exported at the crate root
+  (`motosan_agent_tool::ToolSchema`) so callers can name the schema type
+  without depending on `motosan-agent-primitives` directly.
+  `ToolDef::new(name, description, input_schema)` remains the preferred
+  constructor.
 
 DEPS:
 - `motosan-agent-primitives` path-dep version pin bumped 0.2.0 → 0.3.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 0.6.0 — 2026-05-29
+
+BREAKING:
+- `ToolDef` now composes `motosan_agent_primitives::ToolSchema` via
+  `#[serde(flatten)]`; the serialized wire shape remains unchanged.
+  Field reads (`def.name`, `def.description`, `def.input_schema`) continue
+  to work through `Deref<Target = ToolSchema>`, but struct-literal callers
+  must wrap those fields in `schema: ToolSchema { .. }`.
+
+ADDED:
+- `Deref<Target = ToolSchema>` for `ToolDef`.
+
+DEPS:
+- `motosan-agent-primitives` path-dep version pin bumped 0.2.0 → 0.3.0.
+
 ## 0.5.0 — 2026-05-29
 
 M10 D-M10-4 — Tool display name distinct from internal name. Resolves

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "motosan-agent-primitives"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "motosan-agent-tool"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "boa_engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motosan-agent-tool"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/motosan-dev/motosan-agent-tool"
@@ -29,7 +29,7 @@ browser = ["tokio/process", "tokio/time"]
 all_tools = ["web_search", "fetch_url", "read_file", "read_pdf", "read_spreadsheet", "js_eval", "python_eval", "datetime", "currency_convert", "cost_calculator", "generate_pdf", "browser"]
 
 [dependencies]
-motosan-agent-primitives = { path = "../motosan-agent-primitives", version = "0.2.0" }
+motosan-agent-primitives = { path = "../motosan-agent-primitives", version = "0.3.0" }
 async-trait = "0.1"
 # `tokio-util`'s `CancellationToken` lives in `tokio_util::sync` and is part
 # of the default (featureless) build — no `sync` feature exists to enable.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ registry.register(greet)
 
 This crate unifies the tool interfaces of motosan-chat and crucible-agent:
 
-- **`ToolDef`** — host-side wrapper around `motosan_agent_primitives::ToolSchema`; `name`, `description`, and `input_schema` are flattened on the wire and readable through `Deref`, while `internal_name` is used for host routing/audit. Use `ToolDef::new(...)`, and set `.with_internal_name(...)` when host-side routing needs a namespaced identifier distinct from the LLM-facing `name`.
+- **`ToolDef`** — host-side wrapper around `motosan_agent_primitives::ToolSchema`; `name`, `description`, and `input_schema` are flattened on the wire and readable through `Deref`, while `internal_name` is used for host routing/audit. `ToolDef::new(...)` is the preferred constructor; set `.with_internal_name(...)` when host-side routing needs a namespaced identifier distinct from the LLM-facing `name`. `ToolSchema` itself is re-exported at the crate root (`motosan_agent_tool::ToolSchema`) so you can name it without an extra dependency on `motosan-agent-primitives`.
 - **`ToolResult`** — typed content (`Text` | `Json`) + optional metadata (`citation`, `duration_ms`)
 - **`ToolContext`** — common fields (`caller_id`, `platform`, `cwd`) + extensible `extra` map
 - **`ToolRegistry`** — thread-safe async tool storage

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ registry.register(greet)
 
 This crate unifies the tool interfaces of motosan-chat and crucible-agent:
 
-- **`ToolDef`** — schema validation (type checking, enum checking, required fields); use `ToolDef::new(...)`, and set `.with_internal_name(...)` when host-side routing needs a namespaced identifier distinct from the LLM-facing `name`
+- **`ToolDef`** — host-side wrapper around `motosan_agent_primitives::ToolSchema`; `name`, `description`, and `input_schema` are flattened on the wire and readable through `Deref`, while `internal_name` is used for host routing/audit. Use `ToolDef::new(...)`, and set `.with_internal_name(...)` when host-side routing needs a namespaced identifier distinct from the LLM-facing `name`.
 - **`ToolResult`** — typed content (`Text` | `Json`) + optional metadata (`citation`, `duration_ms`)
 - **`ToolContext`** — common fields (`caller_id`, `platform`, `cwd`) + extensible `extra` map
 - **`ToolRegistry`** — thread-safe async tool storage
@@ -107,10 +107,10 @@ All tools are feature-gated. Enable individually or use `all_tools` to enable al
 ```toml
 # Enable specific tools
 [dependencies]
-motosan-agent-tool = { version = "0.5", features = ["datetime", "web_search"] }
+motosan-agent-tool = { version = "0.6", features = ["datetime", "web_search"] }
 
 # Or enable all
-motosan-agent-tool = { version = "0.5", features = ["all_tools"] }
+motosan-agent-tool = { version = "0.6", features = ["all_tools"] }
 ```
 
 ## Multi-language Support

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,4 +18,6 @@ pub use tool::{Tool, ToolContext, ToolDef, ToolOutput};
 // Convenience re-exports of the wire-format types from primitives so
 // downstream callers can `use motosan_agent_tool::*` without separately
 // depending on `motosan-agent-primitives` for these types.
-pub use motosan_agent_primitives::{ContentBlock, ToolAnnotations, ToolCall, ToolResult};
+pub use motosan_agent_primitives::{
+    ContentBlock, ToolAnnotations, ToolCall, ToolResult, ToolSchema,
+};

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -24,10 +24,10 @@
 //! a wire-format `primitives::ToolResult` at the boundary — see
 //! [`ToolOutput::into_tool_result`].
 
-use std::collections::HashMap;
+use std::{collections::HashMap, ops::Deref};
 
 use async_trait::async_trait;
-use motosan_agent_primitives::{ContentBlock, ToolAnnotations, ToolResult};
+use motosan_agent_primitives::{ContentBlock, ToolAnnotations, ToolResult, ToolSchema};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use tokio_util::sync::CancellationToken;
@@ -71,7 +71,9 @@ pub trait Tool: Send + Sync {
 // ToolDef
 // ---------------------------------------------------------------------------
 
-/// Definition of a tool, suitable for serialization to LLM APIs (Claude, OpenAI, etc.).
+/// Host-side tool definition: the LLM-facing [`ToolSchema`] plus an
+/// `internal_name` used for collision detection / audit correlation
+/// (NOT sent to the model).
 ///
 /// # `name` vs `internal_name`
 ///
@@ -92,21 +94,27 @@ pub trait Tool: Send + Sync {
 /// standard derive — `internal_name` is always emitted.
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct ToolDef {
-    /// Registered tool name.
-    pub name: String,
-    /// Human-readable description shown to the model.
-    pub description: String,
-    /// JSON Schema describing the tool's input shape.
-    pub input_schema: Value,
+    /// Canonical model-visible schema fields, flattened to preserve the
+    /// legacy serialized shape (`name`, `description`, `input_schema`).
+    #[serde(flatten)]
+    pub schema: ToolSchema,
     /// Host-side identifier used for collision detection / audit
-    /// correlation. Defaults to a clone of `name` when constructed via
-    /// [`ToolDef::new`]; override with [`ToolDef::with_internal_name`].
+    /// correlation. Defaults to a clone of `schema.name` when constructed
+    /// via [`ToolDef::new`]; override with [`ToolDef::with_internal_name`].
     ///
     /// This field is NOT sent to the LLM as part of the tool-calling
-    /// protocol — only `name` is. It is, however, included on the
+    /// protocol — only `schema.name` is. It is, however, included on the
     /// `Serialize` side so audit / snapshot consumers persist the full
     /// shape.
     pub internal_name: String,
+}
+
+impl Deref for ToolDef {
+    type Target = ToolSchema;
+
+    fn deref(&self) -> &ToolSchema {
+        &self.schema
+    }
 }
 
 // Helper repr used only by the manual `Deserialize` impl below — keeps
@@ -126,11 +134,14 @@ impl<'de> serde::Deserialize<'de> for ToolDef {
         deserializer: D,
     ) -> std::result::Result<Self, D::Error> {
         let repr = ToolDefRepr::deserialize(deserializer)?;
+        let internal_name = repr.internal_name.unwrap_or_else(|| repr.name.clone());
         Ok(Self {
-            internal_name: repr.internal_name.unwrap_or_else(|| repr.name.clone()),
-            name: repr.name,
-            description: repr.description,
-            input_schema: repr.input_schema,
+            schema: ToolSchema {
+                name: repr.name,
+                description: repr.description,
+                input_schema: repr.input_schema,
+            },
+            internal_name,
         })
     }
 }
@@ -147,12 +158,11 @@ impl ToolDef {
         description: impl Into<String>,
         input_schema: Value,
     ) -> Self {
-        let name = name.into();
+        let schema = ToolSchema::new(name, description, input_schema);
+        let internal_name = schema.name.clone();
         Self {
-            internal_name: name.clone(),
-            name,
-            description: description.into(),
-            input_schema,
+            schema,
+            internal_name,
         }
     }
 
@@ -595,6 +605,18 @@ mod tests {
         let parsed: SearchArgs = def.parse_args(args).unwrap();
         assert_eq!(parsed.query, "rust");
         assert_eq!(parsed.max_results, Some(10));
+    }
+
+    #[test]
+    fn tool_def_composes_flattened_tool_schema() {
+        let def = search_def();
+        assert_eq!(def.schema.name, "web_search");
+        assert_eq!(def.name, "web_search");
+
+        let value = serde_json::to_value(&def).unwrap();
+        assert_eq!(value["name"], "web_search");
+        assert_eq!(value["description"], "Search the web");
+        assert!(value.get("schema").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- bump to 0.6.0 and primitives 0.3.0
- rework ToolDef as a flattened ToolSchema wrapper plus internal_name
- keep construction/deserialization compatibility and docs current

## Gates
- cargo test
- cargo clippy --all-targets -- -D warnings

Phase 7 release not started.
