### PR TITLE
fix: prepare motosan-agent-tool 0.8.1 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Fetch published sibling dependency sources
+        run: |
+          set -euo pipefail
+          fetch() {
+            local crate="$1"
+            local version="$2"
+            local checksum="$3"
+            local archive
+            archive="$(mktemp)"
+            curl -fsSL --retry 3 \
+              "https://crates.io/api/v1/crates/${crate}/${version}/download" \
+              -o "${archive}"
+            echo "${checksum}  ${archive}" | shasum -a 256 -c -
+            tar -xzf "${archive}" -C ..
+            rm -f "${archive}"
+            mv "../${crate}-${version}" "../${crate}"
+          }
+          fetch motosan-agent-primitives 0.4.0 \
+            8d3b346950341babceec436f503ad88426cbea448f825c1543c5953e0d66fe57
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --all-features
 
@@ -21,6 +40,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Fetch published sibling dependency sources
+        run: |
+          set -euo pipefail
+          fetch() {
+            local crate="$1"
+            local version="$2"
+            local checksum="$3"
+            local archive
+            archive="$(mktemp)"
+            curl -fsSL --retry 3 \
+              "https://crates.io/api/v1/crates/${crate}/${version}/download" \
+              -o "${archive}"
+            echo "${checksum}  ${archive}" | shasum -a 256 -c -
+            tar -xzf "${archive}" -C ..
+            rm -f "${archive}"
+            mv "../${crate}-${version}" "../${crate}"
+          }
+          fetch motosan-agent-primitives 0.4.0 \
+            8d3b346950341babceec436f503ad88426cbea448f825c1543c5953e0d66fe57
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -30,6 +68,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Fetch published sibling dependency sources
+        run: |
+          set -euo pipefail
+          fetch() {
+            local crate="$1"
+            local version="$2"
+            local checksum="$3"
+            local archive
+            archive="$(mktemp)"
+            curl -fsSL --retry 3 \
+              "https://crates.io/api/v1/crates/${crate}/${version}/download" \
+              -o "${archive}"
+            echo "${checksum}  ${archive}" | shasum -a 256 -c -
+            tar -xzf "${archive}" -C ..
+            rm -f "${archive}"
+            mv "../${crate}-${version}" "../${crate}"
+          }
+          fetch motosan-agent-primitives 0.4.0 \
+            8d3b346950341babceec436f503ad88426cbea448f825c1543c5953e0d66fe57
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
             local archive
             archive="$(mktemp)"
             curl -fsSL --retry 3 \
-              "https://crates.io/api/v1/crates/${crate}/${version}/download" \
+              "https://static.crates.io/crates/${crate}/${crate}-${version}.crate" \
               -o "${archive}"
             echo "${checksum}  ${archive}" | shasum -a 256 -c -
             tar -xzf "${archive}" -C ..
@@ -50,7 +50,7 @@ jobs:
             local archive
             archive="$(mktemp)"
             curl -fsSL --retry 3 \
-              "https://crates.io/api/v1/crates/${crate}/${version}/download" \
+              "https://static.crates.io/crates/${crate}/${crate}-${version}.crate" \
               -o "${archive}"
             echo "${checksum}  ${archive}" | shasum -a 256 -c -
             tar -xzf "${archive}" -C ..
@@ -78,7 +78,7 @@ jobs:
             local archive
             archive="$(mktemp)"
             curl -fsSL --retry 3 \
-              "https://crates.io/api/v1/crates/${crate}/${version}/download" \
+              "https://static.crates.io/crates/${crate}/${crate}-${version}.crate" \
               -o "${archive}"
             echo "${checksum}  ${archive}" | shasum -a 256 -c -
             tar -xzf "${archive}" -C ..

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ dist/
 
 # IDE
 .pytest_cache/
+
+# macOS
+**/.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## 0.8.1 — 2026-07-12
+## 0.8.1 — 2026-07-16
 
 ### Added
 - `fetch_url` progress phases — the first first-party `ProgressSink` emitter.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ description = "Shared AI agent tool kit — traits, registry, and built-in tools
 authors = ["motosan-dev"]
 keywords = ["ai", "agent", "tool", "llm", "bot"]
 categories = ["development-tools"]
+exclude = ["**/.DS_Store", "docs/superpowers/**"]
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ All tools are feature-gated. Enable individually or use `all_tools` to enable al
 ```toml
 # Enable specific tools
 [dependencies]
-motosan-agent-tool = { version = "0.7", features = ["datetime", "web_search"] }
+motosan-agent-tool = { version = "0.8", features = ["datetime", "web_search"] }
 
 # Or enable all
-motosan-agent-tool = { version = "0.7", features = ["all_tools"] }
+motosan-agent-tool = { version = "0.8", features = ["all_tools"] }
 ```
 
 ## Multi-language Support

--- a/docs/superpowers/plans/2026-07-16-motosan-agent-tool-0.8.1-release.md
+++ b/docs/superpowers/plans/2026-07-16-motosan-agent-tool-0.8.1-release.md
@@ -1,0 +1,152 @@
+# Motosan Agent Tool 0.8.1 Release Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development
+> (if subagents are available) or superpowers:executing-plans to implement this
+> plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce, publish, and tag a reviewed `motosan-agent-tool` 0.8.1
+artifact that unblocks `motosan-agent-loop` 0.49.0 CI and publication.
+
+**Architecture:** Preserve the existing path-plus-version dependency for local
+sibling development. Provision the published primitives source in CI, correct
+release metadata, and publish only from the exact green merge commit.
+
+**Tech Stack:** Rust/Cargo, GitHub Actions, crates.io, Git worktrees.
+
+---
+
+## Task 1: Freeze the release contract
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-07-16-motosan-agent-tool-0.8.1-release-design.md`
+- Create: `docs/superpowers/plans/2026-07-16-motosan-agent-tool-0.8.1-release.md`
+
+- [ ] Review the design and implementation plan against issue `#42`.
+- [ ] Confirm the branch is based on
+      `790699abf210aa8c10bdd52d506c0031eeff5cb1`.
+- [ ] Commit only the two planning files:
+
+```bash
+git add \
+  docs/superpowers/specs/2026-07-16-motosan-agent-tool-0.8.1-release-design.md \
+  docs/superpowers/plans/2026-07-16-motosan-agent-tool-0.8.1-release.md
+git commit -m "feat: plan tool 0.8.1 release (#42)"
+```
+
+## Task 2: Repair CI sibling provisioning
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] Run a failing structural assertion:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+text = Path(".github/workflows/ci.yml").read_text()
+assert text.count("fetch motosan-agent-primitives 0.4.0") == 3
+PY
+```
+
+Expected before the fix: assertion failure because CI provisions zero sibling
+copies.
+
+- [ ] Add the same `fetch` helper and
+      `fetch motosan-agent-primitives 0.4.0` call before Cargo setup in the
+      `test`, `clippy`, and `fmt` jobs.
+- [ ] Re-run the structural assertion and parse the YAML.
+- [ ] Do not change toolchain selection or Cargo commands.
+
+## Task 3: Correct release metadata and package scope
+
+**Files:**
+- Modify: `.gitignore`
+- Modify: `Cargo.toml`
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] Run a failing metadata assertion:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+cargo = Path("Cargo.toml").read_text()
+readme = Path("README.md").read_text()
+changelog = Path("CHANGELOG.md").read_text()
+ignore = Path(".gitignore").read_text()
+assert 'exclude = ["**/.DS_Store", "docs/superpowers/**"]' in cargo
+assert 'version = "0.8"' in readme
+assert "## 0.8.1 — 2026-07-16" in changelog
+assert "**/.DS_Store" in ignore
+PY
+```
+
+Expected before the fix: assertion failure.
+
+- [ ] Add the exact package exclusions, update both README dependency examples
+      to `0.8`, update the changelog date, and ignore `.DS_Store` recursively.
+- [ ] Re-run the metadata assertion.
+- [ ] Run `cargo package --locked --list` and verify neither `.DS_Store` nor
+      `docs/superpowers/` appears.
+
+## Task 4: Verify and commit release preparation
+
+- [ ] Run:
+
+```bash
+cargo fmt -- --check
+cargo clippy --all-features -- -D warnings
+cargo test --all-features
+cargo package --locked
+cargo publish --dry-run --locked
+git diff --check
+```
+
+- [ ] Dispatch specification and code-quality reviews. Resolve every finding
+      and re-run the full gate.
+- [ ] Stage only:
+
+```bash
+git add \
+  .github/workflows/ci.yml \
+  .gitignore \
+  Cargo.toml \
+  README.md \
+  CHANGELOG.md
+git commit -m "fix: prepare tool 0.8.1 release (#42)"
+```
+
+## Task 5: Merge the exact release commit
+
+- [ ] Push only to `origin`.
+- [ ] Create a PR to `main` linked to issue `#42`.
+- [ ] Wait for all GitHub checks to pass.
+- [ ] Merge without force-pushing.
+- [ ] Fetch `origin/main` and record the exact merge commit.
+
+## Task 6: Publish and tag
+
+- [ ] Create or reuse a clean worktree pinned to the exact merged commit.
+- [ ] Re-run the full Task 4 gate.
+- [ ] Verify the authenticated crates.io owner:
+
+```bash
+cargo owner --list motosan-agent-tool
+```
+
+- [ ] Publish:
+
+```bash
+cargo publish --locked
+```
+
+- [ ] Poll the crates.io API until version 0.8.1 is visible.
+- [ ] Create and push the annotated tag on the same commit:
+
+```bash
+git tag -a v0.8.1 -m "motosan-agent-tool 0.8.1"
+git push origin v0.8.1
+```
+
+- [ ] Confirm the registry checksum/version and remote tag commit agree with
+      the release evidence.

--- a/docs/superpowers/specs/2026-07-16-motosan-agent-tool-0.8.1-release-design.md
+++ b/docs/superpowers/specs/2026-07-16-motosan-agent-tool-0.8.1-release-design.md
@@ -1,0 +1,51 @@
+# Motosan Agent Tool 0.8.1 Release Design
+
+## Context
+
+`motosan-agent-loop` 0.49.0 requires `motosan-agent-tool` 0.8.1, but
+crates.io currently stops at 0.8.0. The 0.8.1 source is already merged at
+`790699abf210aa8c10bdd52d506c0031eeff5cb1`. Its local package, clippy, and
+test gates pass when `motosan-agent-primitives` 0.4.0 is available at the
+declared sibling path. GitHub CI fails before compilation because it does not
+provision that sibling.
+
+## Decision
+
+Keep the existing path-plus-version dependency:
+
+```toml
+motosan-agent-primitives = { path = "../motosan-agent-primitives", version = "0.4.0" }
+```
+
+This preserves the sibling-repository development workflow while allowing
+Cargo to normalize the published package to the registry dependency. Each CI
+job downloads the immutable published 0.4.0 source into the expected sibling
+path before invoking Cargo.
+
+Release metadata is corrected on the same reviewed release-prep branch:
+
+- README dependency examples use the current 0.8 line;
+- the 0.8.1 changelog date matches the actual release date;
+- `.DS_Store` is ignored and excluded from the Rust package; and
+- `docs/superpowers/**` is excluded from the Rust package.
+
+No Rust runtime behavior changes in this release-prep train.
+
+## Release Gate
+
+The exact release commit must pass:
+
+```text
+cargo fmt -- --check
+cargo clippy --all-features -- -D warnings
+cargo test --all-features
+cargo package --locked
+cargo publish --dry-run --locked
+```
+
+After the release-prep PR merges and its GitHub checks pass, publish from a
+clean worktree pinned to the merged commit. Verify crates.io exposes 0.8.1
+before creating and pushing annotated tag `v0.8.1` on that same commit.
+
+The registry upload and tag are irreversible release actions and were
+explicitly authorized by the user on 2026-07-16.


### PR DESCRIPTION
## Summary
- provision the published `motosan-agent-primitives 0.4.0` sibling in every CI job
- verify the immutable crate archive checksum before extraction
- align package exclusions, README examples, and the 0.8.1 release date
- document the release design and executable checklist

## Verification
- `cargo fmt -- --check`
- `cargo clippy --all-features -- -D warnings`
- `cargo test --all-features` (184 passed)
- `cargo package --locked --allow-dirty`
- `cargo publish --dry-run --locked --allow-dirty`
- exact CI fetch helper exercised locally

Closes #42